### PR TITLE
Remove native token AVAX from uniswap gemini list

### DIFF
--- a/gemini/avalanche.tokenlist.json
+++ b/gemini/avalanche.tokenlist.json
@@ -15,14 +15,6 @@
   "timestamp": "2021-10-29T14:15:22+0000",
   "tokens": [
     {
-      "name": "Avalanche",
-      "chainId": 43114,
-      "symbol": "AVAX",
-      "decimals": 18,
-      "address": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
-      "logoURI": "https://cryptologos.cc/logos/avalanche-avax-logo.svg"
-    },
-    {
       "name": "Wrapped Avalanche",
       "chainId": 43114,
       "symbol": "WAVAX",

--- a/gemini/ethereum.tokenlist.json
+++ b/gemini/ethereum.tokenlist.json
@@ -239,6 +239,14 @@
       "logoURI": "https://gemini.com/images/currencies/icons/default/usdc.svg"
     },
     {
+      "name": "USDC.e",
+      "chainId": 1,
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "address": "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
+      "logoURI": "https://gemini.com/images/currencies/icons/default/usdc.svg"
+    },
+    {
       "name": "Wrapped Bitcoin",
       "chainId": 1,
       "symbol": "WBTC",


### PR DESCRIPTION
Removing the native AVAX token as its address does not match the 0x format.