### PR TITLE
Fix USDC.e bug on Ethereum's gemini tokenlist

### DIFF
--- a/gemini/avalanche.tokenlist.json
+++ b/gemini/avalanche.tokenlist.json
@@ -127,6 +127,14 @@
       "logoURI": "https://gemini.com/images/currencies/icons/default/uni.svg"
     },
     {
+      "name": "USDC.e",
+      "chainId": 43114,
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "address": "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
+      "logoURI": "https://gemini.com/images/currencies/icons/default/usdc.svg"
+    },
+    {
       "name": "USDC",
       "chainId": 43114,
       "symbol": "USDC",

--- a/gemini/ethereum.tokenlist.json
+++ b/gemini/ethereum.tokenlist.json
@@ -239,14 +239,6 @@
       "logoURI": "https://gemini.com/images/currencies/icons/default/usdc.svg"
     },
     {
-      "name": "USDC.e",
-      "chainId": 1,
-      "symbol": "USDC.e",
-      "decimals": 6,
-      "address": "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
-      "logoURI": "https://gemini.com/images/currencies/icons/default/usdc.svg"
-    },
-    {
       "name": "Wrapped Bitcoin",
       "chainId": 1,
       "symbol": "WBTC",


### PR DESCRIPTION
USDC.e's entry was added to the wrong network (ethereum vs. avalanche)